### PR TITLE
Use Aragon connect

### DIFF
--- a/examples/atomicAgentDeposits/index.js
+++ b/examples/atomicAgentDeposits/index.js
@@ -1,4 +1,4 @@
-const { encodeCallScript } = require('@aragon/test-helpers/evmScript')
+const { encodeCallScript } = require('@aragon/connect-core')
 const { encodeActCall } = require('@aragon/toolkit')
 
 const {
@@ -21,7 +21,7 @@ async function main() {
         encodeCallScript([
           {
             to: tokenAddress,
-            calldata: await encodeActCall(approveSignature, [
+            data: await encodeActCall(approveSignature, [
               receiverAddress,
               amount,
             ]),
@@ -34,7 +34,7 @@ async function main() {
         encodeCallScript([
           {
             to: receiverAddress,
-            calldata: await encodeActCall(depositSignature, [
+            data: await encodeActCall(depositSignature, [
               tokenAddress,
               amount,
               receipt,
@@ -48,15 +48,19 @@ async function main() {
   const actions = await Promise.all(
     scripts.map(async script => ({
       to: agentAddress,
-      calldata: await encodeActCall(forwardSignature, [script]),
+      data: await encodeActCall(forwardSignature, [script]),
     }))
   )
 
   // Encode all actions into a single EVM script.
-  const script = encodeCallScript(actions)
-  console.log(
-    `npx dao exec ${daoAddress} ${votingAddress} newVote ${script} Payments --environment aragon:${environment} --use-frame`
-  )
+  try {
+    const script = await encodeCallScript(actions)
+    console.log(
+      `npx dao exec ${daoAddress} ${votingAddress} newVote ${script} Payments --environment aragon:${environment} --use-frame`
+    )
+  } catch (e){
+    console.error(e)
+  }
 
   process.exit()
 }

--- a/examples/atomicPayments/index.js
+++ b/examples/atomicPayments/index.js
@@ -1,4 +1,4 @@
-const { encodeCallScript } = require('@aragon/test-helpers/evmScript')
+const { encodeCallScript } = require('@aragon/connect-core')
 const { encodeActCall } = require('@aragon/toolkit')
 
 const {
@@ -24,17 +24,21 @@ async function main() {
     )
   )
 
-  const actions = calldatum.map(calldata => ({
+  const actions = calldatum.map(data => ({
     to: financeAddress,
-    calldata,
+    data,
   }))
 
   // Encode all actions into a single EVM script.
-  const script = encodeCallScript(actions)
-  console.log(
-    `npx dao exec ${daoAddress} ${votingAddress} newVote ${script} Payments --environment aragon:${environment} `
-  )
-
+  try {
+    const script = await encodeCallScript(actions)
+    console.log(
+      `npx dao exec ${daoAddress} ${votingAddress} newVote ${script} Payments --environment aragon:${environment} `
+    )
+  } catch (e){
+    console.error(e)
+  }
+  
   process.exit()
 }
 

--- a/examples/mintAndBurn/index.js
+++ b/examples/mintAndBurn/index.js
@@ -1,4 +1,4 @@
-const { encodeCallScript } = require('@aragon/test-helpers/evmScript')
+const { encodeCallScript } = require('@aragon/connect-core')
 const { encodeActCall } = require('@aragon/toolkit')
 
 const {
@@ -23,17 +23,21 @@ async function main() {
     ),
   ])
 
-  const actions = calldatum.map(calldata => ({
+  const actions = calldatum.map(data => ({
     to: tokenManagerAddress,
-    calldata,
+    data,
   }))
 
   // Encode all actions into a single EVM script.
-  const script = encodeCallScript(actions)
-  console.log(
-    `npx dao exec ${daoAddress} ${votingAddress} newVote ${script} MintsAndBurns --environment aragon:${environment} `
-  )
-
+  try {
+    const script = await encodeCallScript(actions)
+    console.log(
+      `npx dao exec ${daoAddress} ${votingAddress} newVote ${script} MintsAndBurns --environment aragon:${environment} `
+    )
+  } catch (e){
+    console.error(e)
+  }
+  
   process.exit()
 }
 

--- a/examples/permissions/index.js
+++ b/examples/permissions/index.js
@@ -1,4 +1,4 @@
-const { encodeCallScript } = require('@aragon/test-helpers/evmScript')
+const { encodeCallScript } = require('@aragon/connect-core')
 const { encodeActCall } = require('@aragon/toolkit')
 const { keccak256 } = require('web3-utils')
 
@@ -29,16 +29,20 @@ async function main() {
     ),
   ])
 
-  const actions = calldatum.map(calldata => ({
+  const actions = calldatum.map(data => ({
     to: aclAddress,
-    calldata,
+    data,
   }))
 
   // Encode all actions into a single EVM script.
-  const script = encodeCallScript(actions)
-  console.log(
-    `npx dao exec ${daoAddress} ${votingAddress} newVote ${script} MintsAndBurns --environment aragon:${environment} `
-  )
+  try {
+    const script = await encodeCallScript(actions)
+    console.log(
+      `npx dao exec ${daoAddress} ${votingAddress} newVote ${script} MintsAndBurns --environment aragon:${environment} `
+    )
+  } catch (e){
+    console.error(e)
+  }  
 
   process.exit()
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aragon-toolkit-examples",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Documented examples of the aragonCLI toolkit tool",
   "main": "index.js",
   "scripts": {
@@ -23,8 +23,8 @@
   },
   "homepage": "https://github.com/sembrestels/aragon-toolkit-examples#readme",
   "dependencies": {
-    "@aragon/test-helpers": "^2.1.0",
-    "@aragon/toolkit": "0.0.1",
+    "@aragon/connect-core": "^0.6.0",
+    "@aragon/toolkit": "0.0.7-beta.1",
     "ethereumjs-abi": "^0.6.8",
     "web3": "^1.2.5-rc.0"
   },


### PR DESCRIPTION
Since the package `@aragon/test-helpers/evmScript` no longer exists on npm, I updated these examples to use `@aragon/connect-core`.

The `calldata` parameter to `encodeActCall` needed to be renamed to `data`, to match what's expected. 

I prepended `await` to `encodeActCall` since it's a promise.  I wrapped some calls in try-catch blocks to prevent unhandled promise rejections.

I only tested `atomicPayments.js`.